### PR TITLE
Replace buggy maze generator with dodecahedron

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,37 @@ impl Maze {
     }
 }
 
+#[test]
+fn test_maze_connected() {
+    use std::collections::HashSet;
+    let rng = Rc::new(RefCell::new(rand::thread_rng()));
+    let maze = Maze::new(rng.clone());
+    let n = maze.rooms.len();
+
+    fn exists_path(
+        i: RoomNum,
+        j: RoomNum,
+        vis: &mut HashSet<RoomNum>,
+        maze: &Maze)
+        -> bool
+    {
+        if i == j {
+            return true;
+        }
+        vis.insert(i);
+        maze.rooms[i].neighbours.iter().any(|neighbour| {
+            // Check that all rooms have three neighbors.
+            let k = neighbour.get().unwrap();
+            !vis.contains(&k) && exists_path(k, j, vis, maze)
+        })
+    }
+    for i in 0..n {
+        for j in 0..n {
+            assert!(exists_path(i, j, &mut HashSet::new(), &maze));
+        }
+    }
+}
+
 ///////////////
 // MAIN LOOP //
 ///////////////


### PR DESCRIPTION
The maze as it currently stands consists of 5 disconnected tetrahedra. That really hurts gameplay.

Commit 47e1331 adds a test for maze connectivity, which fails.

Commit 3d234d1 replaces the maze generator with a hard-wired dodecahedron. The connectivity test now succeeds.